### PR TITLE
Adjustments for new robotiq_s_model_action_server

### DIFF
--- a/tams_ur5_setup_bringup/launch/tams_ur5_setup.launch
+++ b/tams_ur5_setup_bringup/launch/tams_ur5_setup.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <include file="$(find tams_ur5_bringup)/launch/tams_ur5_drivers.launch">
-    <arg name="gripper_mode" value="wide_pinch" />
+    <arg name="gripper_start_mode" value="wide_pinch" />
   </include>
 
   <!-- This argument enables using a customized configuration of the ur5 joint ranges.

--- a/tams_ur5_setup_bringup/launch/tams_ur5_setup_floor_kinect.launch
+++ b/tams_ur5_setup_bringup/launch/tams_ur5_setup_floor_kinect.launch
@@ -6,7 +6,7 @@
 	<arg name="ur5_joint_ranges_config" default="$(find tams_ur5_description)/config/joint_ranges/default.yaml"/>
 
 	<include file="$(find tams_ur5_bringup)/launch/tams_ur5_drivers.launch">
-		<arg name="gripper_mode" value="basic" />
+		<arg name="gripper_start_mode" value="basic" />
 	</include>
 
 	<include file="$(find tams_ur5_setup_description)/launch/tams_ur5_setup_upload.launch">

--- a/tams_ur5_setup_bringup/launch/tams_ur5_setup_floor_kinect2.launch
+++ b/tams_ur5_setup_bringup/launch/tams_ur5_setup_floor_kinect2.launch
@@ -2,7 +2,7 @@
 <launch>
     <arg name="r200" default="false"/>
     <include file="$(find tams_ur5_bringup)/launch/tams_ur5_drivers.launch">
-        <arg name="gripper_mode" value="wide_pinch"/>
+        <arg name="gripper_start_mode" value="wide_pinch"/>
     </include>
 
     <!-- This argument enables using a customized configuration of the ur5 joint ranges.

--- a/tams_ur5_setup_bringup/launch/tams_ur5_setup_floor_kinect2_table.launch
+++ b/tams_ur5_setup_bringup/launch/tams_ur5_setup_floor_kinect2_table.launch
@@ -2,7 +2,7 @@
 <launch>
     <arg name="r200" default="false"/>
     <include file="$(find tams_ur5_bringup)/launch/tams_ur5_drivers.launch">
-        <arg name="gripper_mode" value="wide_pinch"/>
+        <arg name="gripper_start_mode" value="wide_pinch"/>
     </include>
 
     <!-- This argument enables using a customized configuration of the ur5 joint ranges.

--- a/tams_ur5_setup_moveit_config/config/controllers.yaml
+++ b/tams_ur5_setup_moveit_config/config/controllers.yaml
@@ -12,9 +12,7 @@ controller_list:
 
  - name: gripper_action
    action_ns: ""
-   type: GripperCommand
-   default: true
-   command_joint: s_model_finger_middle_joint_1
+   type: FollowJointTrajectory
    joints:
       - s_model_palm_finger_1_joint
       - s_model_finger_1_joint_1

--- a/tams_ur5_setup_moveit_config/config/controllers.yaml
+++ b/tams_ur5_setup_moveit_config/config/controllers.yaml
@@ -2,6 +2,8 @@ controller_list:
  - name: follow_joint_trajectory
    action_ns: ""
    type: FollowJointTrajectory
+   allowed_execution_duration_scaling: 1.2
+   allowed_goal_duration_margin: 0.5
    joints:
       - ur5_shoulder_pan_joint
       - ur5_shoulder_lift_joint
@@ -13,6 +15,8 @@ controller_list:
  - name: gripper_action
    action_ns: ""
    type: FollowJointTrajectory
+   allowed_execution_duration_scaling: 5.0
+   allowed_goal_duration_margin: 0.5
    joints:
       - s_model_palm_finger_1_joint
       - s_model_finger_1_joint_1

--- a/tams_ur5_setup_moveit_config/config/joint_limits.yaml
+++ b/tams_ur5_setup_moveit_config/config/joint_limits.yaml
@@ -7,60 +7,63 @@ max_arm_velocity: &max_arm_velocity
 max_arm_acceleration: &max_arm_acceleration
     max_acceleration: 1.0
 
+max_finger_velocity: &max_finger_velocity
+    max_velocity: 0.5
+
 joint_limits:
   s_model_finger_1_joint_1:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_1_joint_2:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_1_joint_3:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_2_joint_1:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_2_joint_2:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_2_joint_3:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_middle_joint_1:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_middle_joint_2:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_finger_middle_joint_3:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_palm_finger_1_joint:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   s_model_palm_finger_2_joint:
     has_velocity_limits: true
-    max_velocity: 100
+    <<: *max_finger_velocity
     has_acceleration_limits: false
     max_acceleration: 0
   ur5_elbow_joint:

--- a/tams_ur5_setup_moveit_config/config/tams_ur5_setup.srdf
+++ b/tams_ur5_setup_moveit_config/config/tams_ur5_setup.srdf
@@ -28,6 +28,34 @@
         <chain base_link="ur5_base_link" tip_link="s_model_tool0" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+
+    <!-- closed and open are identical to wide_pinch_closed and wide_pinch_open for legacy reasons -->
+    <group_state name="closed" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="0.924553" />
+        <joint name="s_model_finger_1_joint_2" value="0" />
+        <joint name="s_model_finger_1_joint_3" value="-0.977384" />
+        <joint name="s_model_finger_2_joint_1" value="0.924553" />
+        <joint name="s_model_finger_2_joint_2" value="0" />
+        <joint name="s_model_finger_2_joint_3" value="-0.977384" />
+        <joint name="s_model_finger_middle_joint_1" value="0.924553" />
+        <joint name="s_model_finger_middle_joint_2" value="0" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.977384" />
+        <joint name="s_model_palm_finger_1_joint" value="-0.14079" />
+        <joint name="s_model_palm_finger_2_joint" value="0.14079" />
+    </group_state>
+    <group_state name="open" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_1_joint_2" value="0" />
+        <joint name="s_model_finger_1_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_2_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_2_joint_2" value="0" />
+        <joint name="s_model_finger_2_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_middle_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_middle_joint_2" value="0" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.0523599" />
+        <joint name="s_model_palm_finger_1_joint" value="0.191986" />
+        <joint name="s_model_palm_finger_2_joint" value="-0.191986" />
+    </group_state>
     <group_state name="basic_closed" group="gripper">
         <joint name="s_model_finger_1_joint_1" value="1.22173" />
         <joint name="s_model_finger_1_joint_2" value="1.5708" />
@@ -54,7 +82,86 @@
         <joint name="s_model_palm_finger_1_joint" value="-0.016212" />
         <joint name="s_model_palm_finger_2_joint" value="0.016212" />
     </group_state>
-    <group_state name="closed" group="gripper">
+    <group_state name="pinch_closed" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="0.9328077" />
+        <joint name="s_model_finger_1_joint_2" value="0" />
+        <joint name="s_model_finger_1_joint_3" value="-0.9861110" />
+        <joint name="s_model_finger_2_joint_1" value="0.9328077" />
+        <joint name="s_model_finger_2_joint_2" value="0" />
+        <joint name="s_model_finger_2_joint_3" value="-0.9861110" />
+        <joint name="s_model_finger_middle_joint_1" value="0.9328077" />
+        <joint name="s_model_finger_middle_joint_2" value="0" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.9861110" />
+        <joint name="s_model_palm_finger_1_joint" value="-0.1561488" />
+        <joint name="s_model_palm_finger_2_joint" value="0.1561488" />
+    </group_state>
+    <group_state name="pinch_open" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_1_joint_2" value="0" />
+        <joint name="s_model_finger_1_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_2_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_2_joint_2" value="0" />
+        <joint name="s_model_finger_2_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_middle_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_middle_joint_2" value="0" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.0523599" />
+        <joint name="s_model_palm_finger_1_joint" value="-0.1561488" />
+        <joint name="s_model_palm_finger_2_joint" value="0.1561488" />
+    </group_state>
+    <group_state name="wide_closed" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="1.2217304" />
+        <joint name="s_model_finger_1_joint_2" value="1.5707963" />
+        <joint name="s_model_finger_1_joint_3" value="-0.9599310" />
+        <joint name="s_model_finger_2_joint_1" value="1.2217304" />
+        <joint name="s_model_finger_2_joint_2" value="1.5707963" />
+        <joint name="s_model_finger_2_joint_3" value="-0.9599310" />
+        <joint name="s_model_finger_middle_joint_1" value="1.2217304" />
+        <joint name="s_model_finger_middle_joint_2" value="1.5707963" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.9599310" />
+        <joint name="s_model_palm_finger_1_joint" value="0.1766273" />
+        <joint name="s_model_palm_finger_2_joint" value="-0.1766273" />
+    </group_state>
+    <group_state name="wide_open" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_1_joint_2" value="0.0" />
+        <joint name="s_model_finger_1_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_2_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_2_joint_2" value="0.0" />
+        <joint name="s_model_finger_2_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_middle_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_middle_joint_2" value="0.0" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.0523599" />
+        <joint name="s_model_palm_finger_1_joint" value="0.1766273" />
+        <joint name="s_model_palm_finger_2_joint" value="-0.1766273" />
+    </group_state>
+    <group_state name="scissor_closed" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_1_joint_2" value="0.0" />
+        <joint name="s_model_finger_1_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_2_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_2_joint_2" value="0.0" />
+        <joint name="s_model_finger_2_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_middle_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_middle_joint_2" value="0.0" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.0523599" />
+        <joint name="s_model_palm_finger_1_joint" value="-0.1783338" />
+        <joint name="s_model_palm_finger_2_joint" value="0.1783338" />
+    </group_state>
+    <!-- scissor_open is identical to wide_pinch_open. The action server always uses wide_pinch_open. -->
+    <group_state name="scissor_open" group="gripper">
+        <joint name="s_model_finger_1_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_1_joint_2" value="0.0" />
+        <joint name="s_model_finger_1_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_2_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_2_joint_2" value="0.0" />
+        <joint name="s_model_finger_2_joint_3" value="-0.0523599" />
+        <joint name="s_model_finger_middle_joint_1" value="0.0495296" />
+        <joint name="s_model_finger_middle_joint_2" value="0.0" />
+        <joint name="s_model_finger_middle_joint_3" value="-0.0523599" />
+        <joint name="s_model_palm_finger_1_joint" value="0.1919862" />
+        <joint name="s_model_palm_finger_2_joint" value="-0.1919862" />
+    </group_state>
+    <group_state name="wide_pinch_closed" group="gripper">
         <joint name="s_model_finger_1_joint_1" value="0.924553" />
         <joint name="s_model_finger_1_joint_2" value="0" />
         <joint name="s_model_finger_1_joint_3" value="-0.977384" />
@@ -67,7 +174,7 @@
         <joint name="s_model_palm_finger_1_joint" value="-0.14079" />
         <joint name="s_model_palm_finger_2_joint" value="0.14079" />
     </group_state>
-    <group_state name="open" group="gripper">
+    <group_state name="wide_pinch_open" group="gripper">
         <joint name="s_model_finger_1_joint_1" value="0.0495296" />
         <joint name="s_model_finger_1_joint_2" value="0" />
         <joint name="s_model_finger_1_joint_3" value="-0.0523599" />


### PR DESCRIPTION
The new `robotiq_s_model_action_server` changed the `gripper_mode` parameter to the `gripper_start_mode` parameter, thus our launch files had to be changed.

Also the server type was changed to a `FollowJointTrajectory` action server, which has to be set correctly in the `controllers.yaml`. 
Here `allowed_execution_duration_scaling` and `allowed_goal_duration_margin` are now set individually for each controller. The reason for this is that the new while the new action server is of type `FollowJointTrajectory` it does not use the produced trajectories. This leads to longer execution times than moveit predicts and thus to errors and wrong states because of wrong assumptions. To solve this problem the `allowed_execution_duration_scaling` parameter was set to a lot higher value to give more time finish the execution of the trajectory. 

Missing grasp types were added to the `tams_ur5_setup.srdf`. These new grasp types are used by the new 'robotiq_s_model_action_server'.

In `joint_limits.yaml` there is a new `max_finger_velocity` variable to make it easier to set the speeds for the fingers.

This pull request depends on https://github.com/TAMS-Group/robotiq_s_model_action_server/pull/1.