### PR TITLE
Use apriltags2 for tag detection

### DIFF
--- a/tams_ur5_setup_bringup/config/apriltags2/settings.yaml
+++ b/tams_ur5_setup_bringup/config/apriltags2/settings.yaml
@@ -1,0 +1,14 @@
+# AprilTags 2 code parameters
+# Find descriptions in apriltags2/include/apriltag.h:struct apriltag_detector
+#                      apriltags2/include/apriltag.h:struct apriltag_family
+tag_family:        'tag36h11' # options: tag36h11, tag36h10, tag25h9, tag25h7, tag16h5
+tag_border:        1          # default: 1
+tag_threads:       2          # default: 2
+tag_decimate:      1.0        # default: 1.0
+tag_blur:          0.0        # default: 0.0
+tag_refine_edges:  1          # default: 1
+tag_refine_decode: 0          # default: 0
+tag_refine_pose:   0          # default: 0
+tag_debug:         0          # default: 0
+# Other parameters
+publish_tf:        true       # default: false

--- a/tams_ur5_setup_bringup/config/apriltags2/settings.yaml
+++ b/tams_ur5_setup_bringup/config/apriltags2/settings.yaml
@@ -11,4 +11,4 @@ tag_refine_decode: 0          # default: 0
 tag_refine_pose:   0          # default: 0
 tag_debug:         0          # default: 0
 # Other parameters
-publish_tf:        true       # default: false
+publish_tf:        false      # default: false

--- a/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
+++ b/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
@@ -1,49 +1,9 @@
-# # Definitions of tags to detect
-#
-# ## General remarks
-#
-# - All length in meters
-# - Ellipsis (...) signifies that the previous element can be repeated multiple times.
-#
-# ## Standalone tag definitions
-# ### Remarks
-#
-# - name is optional
-#
-# ### Syntax
-#
-# standalone_tags:
-#   [
-#     {id: ID, size: SIZE, name: NAME},
-#     ...
-#   ]
 standalone_tags:
     [
     {id: 0, size: 0.161},
     {id: 352, size: 0.127},
     {id: 42, size: 0.1535}
     ]
-# ## Tag bundle definitions
-# ### Remarks
-#
-# - name is optional
-# - x, y, z have default values of 0 thus they are optional
-# - qw has default value of 1 and qx, qy, qz have default values of 0 thus they are optional
-#
-# ### Syntax
-#
-# tag_bundles:
-#   [
-#     {
-#       name: 'CUSTOM_BUNDLE_NAME',
-#       layout:
-#         [
-#           {id: ID, size: SIZE, x: X_POS, y: Y_POS, z: Z_POS, qw: QUAT_W_VAL, qx: QUAT_X_VAL, qy: QUAT_Y_VAL, qz: QUAT_Z_VAL},
-#           ...
-#         ]
-#     },
-#     ...
-#   ]
 tag_bundles:
-  [
-  ]
+    [
+    ]

--- a/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
+++ b/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
@@ -1,0 +1,49 @@
+# # Definitions of tags to detect
+#
+# ## General remarks
+#
+# - All length in meters
+# - Ellipsis (...) signifies that the previous element can be repeated multiple times.
+#
+# ## Standalone tag definitions
+# ### Remarks
+#
+# - name is optional
+#
+# ### Syntax
+#
+# standalone_tags:
+#   [
+#     {id: ID, size: SIZE, name: NAME},
+#     ...
+#   ]
+standalone_tags:
+[
+    {id: 0, size: 0.161},
+    {id: 352, size: 0.127},
+    {id: 42, size: 0.1535}
+]
+# ## Tag bundle definitions
+# ### Remarks
+#
+# - name is optional
+# - x, y, z have default values of 0 thus they are optional
+# - qw has default value of 1 and qx, qy, qz have default values of 0 thus they are optional
+#
+# ### Syntax
+#
+# tag_bundles:
+#   [
+#     {
+#       name: 'CUSTOM_BUNDLE_NAME',
+#       layout:
+#         [
+#           {id: ID, size: SIZE, x: X_POS, y: Y_POS, z: Z_POS, qw: QUAT_W_VAL, qx: QUAT_X_VAL, qy: QUAT_Y_VAL, qz: QUAT_Z_VAL},
+#           ...
+#         ]
+#     },
+#     ...
+#   ]
+tag_bundles:
+  [
+  ]

--- a/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
+++ b/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
@@ -18,11 +18,11 @@
 #     ...
 #   ]
 standalone_tags:
-[
+    [
     {id: 0, size: 0.161},
     {id: 352, size: 0.127},
     {id: 42, size: 0.1535}
-]
+    ]
 # ## Tag bundle definitions
 # ### Remarks
 #

--- a/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
+++ b/tams_ur5_setup_bringup/config/apriltags2/tags.yaml
@@ -1,7 +1,6 @@
 standalone_tags:
     [
     {id: 0, size: 0.161},
-    {id: 352, size: 0.127},
     {id: 42, size: 0.1535}
     ]
 tag_bundles:

--- a/tams_ur5_setup_bringup/launch/apriltags2.launch
+++ b/tams_ur5_setup_bringup/launch/apriltags2.launch
@@ -1,20 +1,14 @@
 <launch>
-  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
-  <arg name="node_namespace" default="apriltags2_ros_continuous_node" />
-  <arg name="camera_frame" default="camera" />
-  <arg name="camera_name" default="/kinect2/qhd" />
-  <arg name="image_topic" default="image_color_rect" />
-
-  <!-- Set parameters -->
-  <rosparam command="load" file="$(find tams_ur5_setup_bringup)/config/apriltags2/settings.yaml" ns="$(arg node_namespace)" />
-  <rosparam command="load" file="$(find tams_ur5_setup_bringup)/config/apriltags2/tags.yaml" ns="$(arg node_namespace)" />
   
-  <node pkg="apriltags2_ros" type="apriltags2_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+  <node pkg="apriltags2_ros" type="apriltags2_ros_continuous_node" name="apriltags2_ros_continuous_node" clear_params="true" >
     <!-- Remap topics from those used in code to those on the ROS network -->
-    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
-    <remap from="camera_info" to="$(arg camera_name)/camera_info" />
+    <remap from="image_rect" to="/kinect2/qhd/image_color_rect" />
+    <remap from="camera_info" to="/kinect2/qhd/camera_info" />
 
-    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="camera_frame" type="str" value="camera" />
     <param name="publish_tag_detections_image" type="bool" value="false" />      <!-- default: false -->
+
+    <rosparam command="load" file="$(find tams_ur5_setup_bringup)/config/apriltags2/settings.yaml"/>
+    <rosparam command="load" file="$(find tams_ur5_setup_bringup)/config/apriltags2/tags.yaml"/>
   </node>
 </launch>

--- a/tams_ur5_setup_bringup/launch/apriltags2.launch
+++ b/tams_ur5_setup_bringup/launch/apriltags2.launch
@@ -1,0 +1,20 @@
+<launch>
+  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+  <arg name="node_namespace" default="apriltags2_ros_continuous_node" />
+  <arg name="camera_frame" default="camera" />
+  <arg name="camera_name" default="/kinect2/qhd" />
+  <arg name="image_topic" default="image_color_rect" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find tams_ur5_setup_bringup)/config/apriltags2/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find tams_ur5_setup_bringup)/config/apriltags2/tags.yaml" ns="$(arg node_namespace)" />
+  
+  <node pkg="apriltags2_ros" type="apriltags2_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+    <!-- Remap topics from those used in code to those on the ROS network -->
+    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
+    <remap from="camera_info" to="$(arg camera_name)/camera_info" />
+
+    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="publish_tag_detections_image" type="bool" value="false" />      <!-- default: false -->
+  </node>
+</launch>

--- a/tams_ur5_setup_bringup/launch/kinect.launch
+++ b/tams_ur5_setup_bringup/launch/kinect.launch
@@ -3,10 +3,8 @@
 	<include file="$(find freenect_launch)/launch/freenect.launch">
 		<arg name="depth_registration" value="true" />
 	</include>
-        <node pkg="apriltags_ros" type="apriltag_detector_node" name="apriltag_detector">
-		<rosparam param="tag_descriptions">[{id: 0, size: 0.161}]</rosparam>
-		<remap from="/image_rect" to="/camera/rgb/image_rect_color"/>
-		<remap from="/camera_info" to="/camera/rgb/camera_info"/>
-	</node>
+
+	<include file="$(find tams_ur5_setup_bringup)/launch/apriltags2.launch"/>
+
 	<include file="$(find camera_positioner)/launch/camera_positioner.launch"/>
 </launch>

--- a/tams_ur5_setup_bringup/launch/kinect2.launch
+++ b/tams_ur5_setup_bringup/launch/kinect2.launch
@@ -4,11 +4,9 @@
 		<arg name="publish_tf" value="true"/>
 		<arg name="calib_path" value="$(find tams_ur5_setup_bringup)/config/kinect2_calib/" />
 	</include>
-	<node pkg="apriltags_ros" type="apriltag_detector_node" name="apriltag_detector">
-		<rosparam param="tag_descriptions">[{id: 0, size: 0.161}]</rosparam>
-		<remap from="/image_rect" to="/kinect2/qhd/image_color_rect"/>
-		<remap from="/camera_info" to="/kinect2/qhd/camera_info"/>
-	</node>
+
+	<include file="$(find tams_ur5_setup_bringup)/launch/apriltags2.launch"/>
+
 	<node pkg="camera_positioner" type="camera_positioner" name="camera_positioner">
 		<param name="camera_rgb_optical_frame" value="kinect2_rgb_optical_frame"/>
 		<param name="camera_link" value="kinect2_link"/>

--- a/tams_ur5_setup_bringup/launch/kinect2_table.launch
+++ b/tams_ur5_setup_bringup/launch/kinect2_table.launch
@@ -4,11 +4,9 @@
 		<arg name="publish_tf" value="true"/>
 		<arg name="calib_path" value="$(find tams_ur5_setup_bringup)/config/kinect2_calib/" />
 	</include>
-	<node pkg="apriltags_ros" type="apriltag_detector_node" name="apriltag_detector">
-		<rosparam param="tag_descriptions">[{id: 0, size: 0.161},{id: 42, size: 0.1535}]</rosparam>
-		<remap from="/image_rect" to="/kinect2/qhd/image_color_rect"/>
-		<remap from="/camera_info" to="/kinect2/qhd/camera_info"/>
-	</node>
+
+	<include file="$(find tams_ur5_setup_bringup)/launch/apriltags2.launch"/>
+
 	<node pkg="camera_positioner" type="camera_positioner_table" name="camera_positioner_table">
 		<param name="camera_rgb_optical_frame" value="kinect2_rgb_optical_frame"/>
 		<param name="camera_link" value="kinect2_link"/>

--- a/tams_ur5_setup_bringup/package.xml
+++ b/tams_ur5_setup_bringup/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>apriltags_ros</run_depend>
+  <run_depend>apriltags2_ros</run_depend>
   <run_depend>camera_positioner</run_depend>
   <run_depend>openni2_launch</run_depend>
   <run_depend>tams_ur5_bringup</run_depend>


### PR DESCRIPTION
The new [apriltags2](http://wiki.ros.org/apriltags2_ros) package enables faster and more robust april tag detection. With default settings apriltags2 detects a single tag at a rate of 10+, which is 3x better compared to using the old package in the same scenario.
The performance improvement is a lot more apparent when using multiple tags since the rate does not decrease that much.

Also apriltags2 allows defining bundles - namely groups of tags that belong to the same object with fixed relative transforms.
The bundles frame is averaged between the detected transforms so that a reliable detection even given if only some of the tags are visible.