### PR TITLE
update launch file to set hw_interface

### DIFF
--- a/tams_ur5_setup_description/launch/tams_ur5_setup_upload.launch
+++ b/tams_ur5_setup_description/launch/tams_ur5_setup_upload.launch
@@ -3,6 +3,10 @@
   <arg name="joint_ranges_config" default="$(find tams_ur5_description)/config/joint_ranges/default.yaml" />
   <arg name="floating_table" default="false" />
   <arg name="r200" default="false" />
-
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find tams_ur5_setup_description)/urdf/tams_ur5_setup.urdf.xacro' joint_ranges_config:=$(arg joint_ranges_config) floating_table:=$(arg floating_table) r200:=$(arg r200)" />
+  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find tams_ur5_setup_description)/urdf/tams_ur5_setup.urdf.xacro'
+    joint_ranges_config:=$(arg joint_ranges_config)
+    floating_table:=$(arg floating_table)
+    r200:=$(arg r200)
+    transmission_hw_interface:=$(arg transmission_hw_interface)" />
 </launch>


### PR DESCRIPTION
according to the upstream update, ros-industrial/universal_robot#392
We need to update our ur5 xacro file to pass hw_interface as hardware_interface/PositionJointInterface
so the launch file can also be updated for setting hw_interface