### PR TITLE
Deprecated: xacro tag 'insert_block' w/o 'xacro:' xml namespace

### DIFF
--- a/tams_ur5_setup_description/urdf/tams_ur5_setup.urdf.xacro
+++ b/tams_ur5_setup_description/urdf/tams_ur5_setup.urdf.xacro
@@ -5,7 +5,7 @@
   <xacro:property name="pi" value="3.1415926535897931" />
   <!-- tams corner -->
   <xacro:include filename="$(find tams_ur5_setup_description)/urdf/tams_corner.urdf.xacro">
-    <arg name="floating_table" value="$(arg floating_table)" />
+    <xacro:arg name="floating_table" value="$(arg floating_table)" />
   </xacro:include>
   <!-- arm -->
   <xacro:include filename="$(find tams_ur5_description)/urdf/arm.urdf.xacro" />


### PR DESCRIPTION
Deprecated: xacro tag 'insert_block' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)

Use the following command to fix incorrect tag usage:
find . -iname "*.xacro" | xargs sed -i 's#<\([/]\?\)\(if\|unless\|include\|arg\|property\|macro\|insert_block\)#<\1xacro:\2#g'
