### PR TITLE
Remove unused dep to deprecated ur5 repo

### DIFF
--- a/tams_ur5_setup_bringup/package.xml
+++ b/tams_ur5_setup_bringup/package.xml
@@ -13,6 +13,5 @@
   <run_depend>apriltag_ros</run_depend>
   <run_depend>camera_positioner</run_depend>
   <run_depend>openni2_launch</run_depend>
-  <run_depend>tams_ur5_bringup</run_depend>
   <run_depend>tams_ur5_setup_description</run_depend>
 </package>


### PR DESCRIPTION
Remove dependency on https://github.com/TAMS-Group/tams_ur5. The dep seems to be unused and the required repo is deprecated.